### PR TITLE
Fix line buffer support for darwin

### DIFF
--- a/include/fast_io_legacy_impl/c/unix.h
+++ b/include/fast_io_legacy_impl/c/unix.h
@@ -329,4 +329,12 @@ inline bool ibuffer_underflow(u8c_io_observer_unlocked cio)
 	return details::bsd_underflow_impl(cio.fp);
 }
 
+#if defined(__MSDOS__) || defined(__DARWIN_C_LEVEL)
+template <::std::integral ch_type>
+inline bool obuffer_is_line_buffering_define(basic_c_io_observer_unlocked<ch_type> ciou) noexcept
+{
+	return details::bsd_get_buffer_ptr_impl<char8_t, 2>(ciou.fp) <
+		   details::bsd_get_buffer_ptr_impl<char8_t, 1>(ciou.fp);
+}
+#endif
 }


### PR DESCRIPTION
it looks like apple platform does something what glibc does. i am not sure whether freebsd has the same issue, but android does not